### PR TITLE
Fetch and Store Rockets Data :100: 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
+        "axios": "^1.4.0",
         "bootstrap": "^5.3.0",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
@@ -5203,6 +5204,29 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14912,6 +14936,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
+    "axios": "^1.4.0",
     "bootstrap": "^5.3.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Route, Routes } from 'react-router-dom';
 
 import Header from './components/header';
 import RocketsPage from './pages/rockets';
+import { fetchRockets } from './redux/rockets/rockets-slice';
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchRockets());
+  }, [dispatch]);
+
   return (
     <>
       <header>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './styles/index.css';
 import App from './App';
+import store from './redux/config-store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+    ,
+  </Provider>,
 );

--- a/src/redux/config-store.js
+++ b/src/redux/config-store.js
@@ -1,1 +1,10 @@
-// config store
+import { configureStore } from '@reduxjs/toolkit';
+import rocketsReducer from './rockets/rockets-slice';
+
+const store = configureStore({
+  reducer: {
+    rockets: rocketsReducer,
+  },
+});
+
+export default store;

--- a/src/redux/rockets/rockets-slice.js
+++ b/src/redux/rockets/rockets-slice.js
@@ -1,1 +1,24 @@
-// rockets component
+// rocket-slice.js
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export const fetchRockets = createAsyncThunk('rocket/fetchRockets', async () => {
+  const response = await axios.get('https://api.spacexdata.com/v3/rockets');
+  return response.data.map(({
+    id, name, type, flickrImages,
+  }) => ({
+    id, name, type, flickrImages,
+  }));
+});
+
+export const rocketSlice = createSlice({
+  name: 'rocket',
+  initialState: { rockets: [] },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchRockets.fulfilled, (state, action) => ({ ...state, rockets: action.payload }));
+  },
+});
+
+export default rocketSlice.reducer;

--- a/src/redux/rockets/rockets-slice.js
+++ b/src/redux/rockets/rockets-slice.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 export const fetchRockets = createAsyncThunk('rocket/fetchRockets', async () => {
   const response = await axios.get('https://api.spacexdata.com/v3/rockets');
   return response.data.map(({
-    id, name, type, flickrImages,
+    id, rocket_name: name, rocket_type: type, flickr_images: flickrImages,
   }) => ({
     id, name, type, flickrImages,
   }));

--- a/src/redux/rockets/rockets-slice.js
+++ b/src/redux/rockets/rockets-slice.js
@@ -1,24 +1,45 @@
-// rocket-slice.js
+// rockets-slice.js
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
-export const fetchRockets = createAsyncThunk('rocket/fetchRockets', async () => {
-  const response = await axios.get('https://api.spacexdata.com/v3/rockets');
-  return response.data.map(({
-    id, rocket_name: name, rocket_type: type, flickr_images: flickrImages,
-  }) => ({
-    id, name, type, flickrImages,
-  }));
+export const fetchRockets = createAsyncThunk('rockets/fetchRockets', async () => {
+  try {
+    const response = await axios.get('https://api.spacexdata.com/v3/rockets');
+    return response.data.map(({
+      id, rocket_name: name, description, flickr_images: flickrImages,
+    }) => ({
+      id,
+      name,
+      description,
+      flickrImages,
+    }));
+  } catch (error) {
+    return error;
+  }
 });
 
-export const rocketSlice = createSlice({
-  name: 'rocket',
-  initialState: { rockets: [] },
+export const rocketsSlice = createSlice({
+  name: 'rockets',
+  initialState: { rockets: [], loading: false, error: null },
   reducers: {},
   extraReducers: (builder) => {
     builder
-      .addCase(fetchRockets.fulfilled, (state, action) => ({ ...state, rockets: action.payload }));
+      .addCase(fetchRockets.pending, (state) => ({
+        ...state,
+        loading: true,
+        error: null,
+      }))
+      .addCase(fetchRockets.fulfilled, (state, action) => ({
+        ...state,
+        loading: false,
+        rockets: action.payload,
+      }))
+      .addCase(fetchRockets.rejected, (state, action) => ({
+        ...state,
+        loading: false,
+        error: action.error.message,
+      }));
   },
 });
 
-export default rocketSlice.reducer;
+export default rocketsSlice.reducer;


### PR DESCRIPTION
# 🚀 Fetch and Store Rockets Data in Redux Store on App Load #17

This PR fetches data from the Rockets endpoint ([https://api.spacexdata.com/v3/rockets) 🌌 ↗](https://api.spacexdata.com/v3/rockets)) when the application starts and stores the selected data in the Redux store. This will allow the Rockets view to display the rockets' id, name, type, and flickr images 🚀🌎.

## Done
- [x] Create `fetchRockets` async thunk to retrieve Rockets data from SpaceX API 🚀
- [x] Modify `rocketSlice` to store the retrieved Rockets data in the Redux store 📦
- [x] Dispatch actions to fetch and store Rockets data only once, and avoid adding data to the store on every re-render 🚫🔄
- [x] Update `rocketSlice` to map API response data to the shape {id, name, type, flickrImages} 🔄
- [x] Add `useEffect` hook to fetch Rockets data from the SpaceX API when the application loads 🎣

## Highlights
- ✨ Added Redux store to the application
- 🚀 Fetching and storing data from the SpaceX Rockets API
- 🔍 Using selectors to retrieve data from the Redux store

### Let me know if you have any further questions or if you'd like me to make any changes! :question: :eyes: 

![giphy](https://github.com/ITurres/spacex-travelers-hub/assets/57197702/8336e08b-ed28-4e6f-9148-874cb3acae38)
