### PR TITLE
Implement rocket booking cancellation Redux action :runner: 

### DIFF
--- a/src/components/rockets/RocketCard.jsx
+++ b/src/components/rockets/RocketCard.jsx
@@ -1,12 +1,22 @@
 import { Card, Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { reserveRocket } from '../../redux/rockets/rockets-slice';
 
 const RocketCard = ({ rocketProps }) => {
+  const dispatch = useDispatch();
+
   const {
+    id,
     name,
     description,
     flickrImages,
+    reserved,
   } = rocketProps;
+
+  const handleReserveRocket = () => {
+    dispatch(reserveRocket(id));
+  };
 
   return (
     <Card>
@@ -20,7 +30,12 @@ const RocketCard = ({ rocketProps }) => {
             <Card.Text style={{ maxHeight: '221px', overflow: 'auto' }}>
               {description}
             </Card.Text>
-            <Button variant="outline-primary">Reserve Rocket</Button>
+            {!reserved && (
+              <Button variant="outline-primary" onClick={handleReserveRocket}>
+                Reserve Rocket
+              </Button>
+            )}
+            {reserved && <p>Rocket reserved!</p>}
           </Card.Body>
         </div>
       </div>
@@ -30,6 +45,7 @@ const RocketCard = ({ rocketProps }) => {
 
 RocketCard.defaultProps = {
   rocketProps: {},
+  id: '',
   name: '',
   description: '',
   flickrImages: [],
@@ -37,10 +53,13 @@ RocketCard.defaultProps = {
 
 RocketCard.propTypes = {
   rocketProps: PropTypes.shape({
+    id: PropTypes.string,
     name: PropTypes.string,
     description: PropTypes.string,
     flickrImages: PropTypes.arrayOf(PropTypes.string),
+    reserved: PropTypes.bool,
   }),
+  id: PropTypes.string,
   name: PropTypes.string,
   description: PropTypes.string,
   flickrImages: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/rockets/RocketCard.jsx
+++ b/src/components/rockets/RocketCard.jsx
@@ -1,7 +1,8 @@
+import React from 'react';
 import { Card, Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { reserveRocket } from '../../redux/rockets/rockets-slice';
+import { reserveRocket, cancelRocket } from '../../redux/rockets/rockets-slice';
 
 const RocketCard = ({ rocketProps }) => {
   const dispatch = useDispatch();
@@ -16,6 +17,10 @@ const RocketCard = ({ rocketProps }) => {
 
   const handleReserveRocket = () => {
     dispatch(reserveRocket(id));
+  };
+
+  const handleCancelRocket = () => {
+    dispatch(cancelRocket(id));
   };
 
   return (
@@ -35,7 +40,11 @@ const RocketCard = ({ rocketProps }) => {
                 Reserve Rocket
               </Button>
             )}
-            {reserved && <p>Rocket reserved!</p>}
+            {reserved && (
+              <Button variant="outline-danger" onClick={handleCancelRocket}>
+                Cancel Booking
+              </Button>
+            )}
           </Card.Body>
         </div>
       </div>

--- a/src/redux/rockets/rockets-slice.js
+++ b/src/redux/rockets/rockets-slice.js
@@ -30,6 +30,13 @@ export const rocketsSlice = createSlice({
         rocket.reserved = true;
       }
     },
+    cancelRocket: (state, action) => {
+      const { payload: rocketId } = action;
+      const rocket = state.rockets.find((rocket) => rocket.id === rocketId);
+      if (rocket) {
+        rocket.reserved = false;
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -51,6 +58,6 @@ export const rocketsSlice = createSlice({
   },
 });
 
-export const { reserveRocket } = rocketsSlice.actions;
+export const { reserveRocket, cancelRocket } = rocketsSlice.actions;
 
 export default rocketsSlice.reducer;

--- a/src/redux/rockets/rockets-slice.js
+++ b/src/redux/rockets/rockets-slice.js
@@ -12,6 +12,7 @@ export const fetchRockets = createAsyncThunk('rockets/fetchRockets', async () =>
       name,
       description,
       flickrImages,
+      reserved: false,
     }));
   } catch (error) {
     return error;
@@ -21,7 +22,15 @@ export const fetchRockets = createAsyncThunk('rockets/fetchRockets', async () =>
 export const rocketsSlice = createSlice({
   name: 'rockets',
   initialState: { rockets: [], loading: false, error: null },
-  reducers: {},
+  reducers: {
+    reserveRocket: (state, action) => {
+      const { payload: rocketId } = action;
+      const rocket = state.rockets.find((rocket) => rocket.id === rocketId);
+      if (rocket) {
+        rocket.reserved = true;
+      }
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchRockets.pending, (state) => ({
@@ -41,5 +50,7 @@ export const rocketsSlice = createSlice({
       }));
   },
 });
+
+export const { reserveRocket } = rocketsSlice.actions;
 
 export default rocketsSlice.reducer;


### PR DESCRIPTION
# Implement rocket booking cancellation #8 

🚀 This PR implements the ability to cancel a rocket booking by setting the `reserved` key to `false`, following the same logic as the "Reserve rocket" functionality. :100: 

## Done :heavy_check_mark: 
- [x] Add `cancelRocket` reducer to `rockets-slice.js` to set the `reserved` property of a rocket to `false`
- [x] Implement `handleCancelRocket` function in `RocketCard.js` to dispatch `cancelRocket` action upon clicking the "Cancel Booking" button

## Highlights 🔍
- Added cancellation functionality for rocket bookings
- Used existing logic to keep code consistent and easy to maintain

🎉 Thank you for reviewing!