### PR TITLE
Added switch badges for Rockets - Conditional components 🏷️

### DIFF
--- a/src/components/rockets/RocketCard.jsx
+++ b/src/components/rockets/RocketCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Button } from 'react-bootstrap';
+import { Card, Button, Badge } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { reserveRocket, cancelRocket } from '../../redux/rockets/rockets-slice';
@@ -8,11 +8,7 @@ const RocketCard = ({ rocketProps }) => {
   const dispatch = useDispatch();
 
   const {
-    id,
-    name,
-    description,
-    flickrImages,
-    reserved,
+    id, name, description, flickrImages, reserved,
   } = rocketProps;
 
   const handleReserveRocket = () => {
@@ -33,16 +29,21 @@ const RocketCard = ({ rocketProps }) => {
           <Card.Body>
             <Card.Title>{name}</Card.Title>
             <Card.Text style={{ maxHeight: '221px', overflow: 'auto' }}>
+              {reserved && (
+                <Badge variant="info" bg="info" className="mb-2">
+                  Reserved
+                </Badge>
+              )}
+              &nbsp;
               {description}
             </Card.Text>
-            {!reserved && (
+            {reserved ? (
+              <Button variant="outline-danger" onClick={handleCancelRocket}>
+                Cancel Reservation
+              </Button>
+            ) : (
               <Button variant="outline-primary" onClick={handleReserveRocket}>
                 Reserve Rocket
-              </Button>
-            )}
-            {reserved && (
-              <Button variant="outline-danger" onClick={handleCancelRocket}>
-                Cancel Booking
               </Button>
             )}
           </Card.Body>

--- a/src/components/rockets/RocketCard.jsx
+++ b/src/components/rockets/RocketCard.jsx
@@ -55,7 +55,7 @@ const RocketCard = ({ rocketProps }) => {
 
 RocketCard.defaultProps = {
   rocketProps: {},
-  id: '',
+  id: 0,
   name: '',
   description: '',
   flickrImages: [],
@@ -63,13 +63,13 @@ RocketCard.defaultProps = {
 
 RocketCard.propTypes = {
   rocketProps: PropTypes.shape({
-    id: PropTypes.string,
+    id: PropTypes.number,
     name: PropTypes.string,
     description: PropTypes.string,
     flickrImages: PropTypes.arrayOf(PropTypes.string),
     reserved: PropTypes.bool,
   }),
-  id: PropTypes.string,
+  id: PropTypes.number,
   name: PropTypes.string,
   description: PropTypes.string,
   flickrImages: PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
## Summary :writing_hand: 
🚀 This pull request adds a "Reserved" badge and a "Cancel reservation" button to the `RocketCard` component for rockets that have already been reserved. When a rocket is reserved, the "Reserve rocket" button is replaced with the "Cancel reservation" button, and the "Reserved" badge is displayed next to the rocket name. This change is in line with the design requirements.

## Changes Made :heavy_check_mark: 

- [x] 🎨 Updated the `RocketCard` component to conditionally render the "Reserved" badge and the "Cancel reservation" button when a rocket is reserved
- [x] ✨ Used the React conditional rendering syntax (`{rocket.reserved && (...)}`) to conditionally render the elements
- [x] 🎉 Added a "Reserved" badge with the `variant="info"` and `bg="info"` props to match the design requirements
- [x] 📏 Removed the `mb-2` class from the `Badge` component and added it to the parent `div` element for consistent spacing
- [x] 🖋️ Updated the `Card.Text` component to display the "Reserved" badge and the description on the same line

## Highlights :dart: 

- 🚀 Added a "Reserved" badge and a "Cancel reservation" button to the `RocketCard` component for reserved rockets
- ✨ Used the React conditional rendering syntax to conditionally render the elements
- 🎨 Added the `variant="info"` and `bg="info"` props to the `Badge` component to match the design requirements
- 📏 Removed the `mb-2` class from the `Badge` component and added it to the parent `div` element for consistent spacing
- 🖋️ Updated the `Card.Text` component to display the "Reserved" badge and the description on the same line

## Related Issue(s) :link: 
#5 
