### PR TITLE
Issue #6🎫 - Feature: missions switch badges

### DIFF
--- a/src/components/missions/MissionRow.jsx
+++ b/src/components/missions/MissionRow.jsx
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+import { joinMission } from '../../redux/missions/missions-slice';
+
+const MissionRow = ({ mission }) => {
+  const dispatch = useDispatch();
+
+  const {
+    missionId, missionName, description, reserved,
+  } = mission;
+
+  const handleMissionActions = () => {
+    if (!reserved) return;
+    dispatch(joinMission(missionId));
+  };
+
+  return (
+    <tr key={missionId}>
+      <td>
+        <strong>{missionName}</strong>
+      </td>
+      <td>{description}</td>
+      <td className="p-3">STATUS BADGE</td>
+      <td className="p-3">
+        {reserved ? (
+          <Button variant="outline-danger" size="sm">
+            Leave Mission
+          </Button>
+        ) : (
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={handleMissionActions}
+          >
+            Join Mission
+          </Button>
+        )}
+      </td>
+    </tr>
+  );
+};
+
+MissionRow.propTypes = {
+  mission: PropTypes.shape({
+    missionId: PropTypes.string.isRequired,
+    missionName: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    reserved: PropTypes.bool.isRequired,
+  }).isRequired,
+};
+
+export default MissionRow;

--- a/src/components/missions/MissionRow.jsx
+++ b/src/components/missions/MissionRow.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
-import { joinMission } from '../../redux/missions/missions-slice';
+import { joinMission, leaveMission } from '../../redux/missions/missions-slice';
 
 const MissionRow = ({ mission }) => {
   const dispatch = useDispatch();
@@ -10,9 +10,12 @@ const MissionRow = ({ mission }) => {
     missionId, missionName, description, reserved,
   } = mission;
 
-  const handleMissionActions = () => {
-    if (!reserved) return;
+  const handleMissionJoin = () => {
     dispatch(joinMission(missionId));
+  };
+
+  const handleMissionLeave = () => {
+    dispatch(leaveMission(missionId));
   };
 
   return (
@@ -24,14 +27,18 @@ const MissionRow = ({ mission }) => {
       <td className="p-3">STATUS BADGE</td>
       <td className="p-3">
         {reserved ? (
-          <Button variant="outline-danger" size="sm">
+          <Button
+            variant="outline-danger"
+            size="sm"
+            onClick={handleMissionLeave}
+          >
             Leave Mission
           </Button>
         ) : (
           <Button
             variant="outline-secondary"
             size="sm"
-            onClick={handleMissionActions}
+            onClick={handleMissionJoin}
           >
             Join Mission
           </Button>

--- a/src/components/missions/MissionRow.jsx
+++ b/src/components/missions/MissionRow.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import { Button, Badge } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
 import { joinMission, leaveMission } from '../../redux/missions/missions-slice';
 
@@ -25,7 +25,25 @@ const MissionRow = ({ mission }) => {
       </td>
       <td>{description}</td>
       <td className="p-3">STATUS BADGE</td>
-      <td className="p-3">
+      <td className="p-3" style={{ verticalAlign: 'middle' }}>
+        {reserved ? (
+          <Badge variant="info" bg="info">
+            Active Member
+          </Badge>
+        ) : (
+          <Badge variant="secondary" bg="secondary">
+            NOT A MEMBER
+          </Badge>
+        )}
+      </td>
+      <td
+        className="p-3"
+        style={{
+          minWidth: '140px',
+          textAlign: 'center',
+          verticalAlign: 'middle',
+        }}
+      >
         {reserved ? (
           <Button
             variant="outline-danger"

--- a/src/components/missions/MissionsList.jsx
+++ b/src/components/missions/MissionsList.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
+import MissionRow from './MissionRow';
 
 const MissionsList = ({ missions }) => (
   <Table striped bordered responsive="sm">
@@ -13,27 +14,14 @@ const MissionsList = ({ missions }) => (
     </thead>
     <tbody>
       {missions.map((mission) => (
-        <tr key={mission.missionId}>
-          <td>
-            <strong>{mission.missionName}</strong>
-          </td>
-          <td>{mission.description}</td>
-          <td className="p-3">STATUS BADGE</td>
-          <td className="p-3">JOIN MISSION BUTTON</td>
-        </tr>
+        <MissionRow key={mission.missionId} mission={mission} />
       ))}
     </tbody>
   </Table>
 );
 
 MissionsList.propTypes = {
-  missions: PropTypes.arrayOf(
-    PropTypes.shape({
-      missionId: PropTypes.string.isRequired,
-      missionName: PropTypes.string.isRequired,
-      description: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
+  missions: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 
 export default MissionsList;

--- a/src/redux/missions/missions-slice.js
+++ b/src/redux/missions/missions-slice.js
@@ -44,6 +44,14 @@ const missionsSlice = createSlice({
         mission.reserved = true;
       }
     },
+    leaveMission: (state, action) => {
+      const mission = state.missions.find(
+        (mission) => mission.missionId === action.payload,
+      );
+      if (mission) {
+        mission.reserved = false;
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -66,6 +74,6 @@ const missionsSlice = createSlice({
   },
 });
 
-export const { joinMission } = missionsSlice.actions;
+export const { joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/redux/missions/missions-slice.js
+++ b/src/redux/missions/missions-slice.js
@@ -18,6 +18,7 @@ export const fetchMissions = createAsyncThunk(
           missionId,
           missionName,
           description,
+          reserved: false,
         }),
       );
       return missionsFilteredData;
@@ -34,7 +35,16 @@ const missionsSlice = createSlice({
     isLoading: false,
     error: null,
   },
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const mission = state.missions.find(
+        (mission) => mission.missionId === action.payload,
+      );
+      if (mission) {
+        mission.reserved = true;
+      }
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchMissions.pending, (state) => ({
@@ -55,5 +65,7 @@ const missionsSlice = createSlice({
       }));
   },
 });
+
+export const { joinMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
# 🚩I have made the following changes to complete Issue #6🎫

## Here is a summary of what has been done based on the content of **`feature/actions-mission-leaving`** >>[branch](https://github.com/ITurres/spacex-travelers-hub/pull/41)<<

### Type of **`files`** changed/added

![My Skills](https://skillicons.dev/icons?i=react)

### In this new Branch, I have **✏️MODIFIED✏️** the succeeding **\*📂 folders** and/or **\*\*📄 files** to complete this Issue's [requirements](https://github.com/ITurres/spacex-travelers-hub/issues/6)

# \*📂 root/

- ## \*📂 src/

  - ### \*📂 components/missions/

    - **\*\*📄 MissionsRow.jsx** ✏️

      > I have added a React conditional render to the **`MissionsRow`** **`Badge`** component to display the **Mission Status** as a **`Badge`** on the mission row. If the mission is 'active' the **`Badge`** will be displayed as **Active Member** and if the mission is 'inactive' the **`Badge`** will be displayed as **NOT A MEMBER**.

---

### Thank you for taking the time to review this PR ⭐

---

If you require additional information or have any questions, please feel free to contact me on Slack as _**Arturo (Arthur) Emanuel Guerra Iturres**_. I'll be happy to assist you. 🎯

---
